### PR TITLE
Bugfix

### DIFF
--- a/LobitaBot/LobitaBot/Persistence/DbCharacterIndex.cs
+++ b/LobitaBot/LobitaBot/Persistence/DbCharacterIndex.cs
@@ -29,7 +29,7 @@ namespace LobitaBot
 
         public PostData LookupNextPost(string searchTerm, int index)
         {
-            if (_cacheService.CharacterInCache(searchTerm))
+            if (_cacheService.CharacterInCache(searchTerm) && _cacheService.CharacterAloneInCache(searchTerm))
             {
                 return _cacheService.CacheNext(index);
             }
@@ -47,7 +47,7 @@ namespace LobitaBot
 
         public PostData LookupPreviousPost(string searchTerm, int index)
         {
-            if (_cacheService.CharacterInCache(searchTerm))
+            if (_cacheService.CharacterInCache(searchTerm) && _cacheService.CharacterAloneInCache(searchTerm))
             {
                 return _cacheService.CachePrevious(index);
             }


### PR DESCRIPTION
Before this fix, the back and forward-buttons worked incorrectly for the following situation: roll character, roll series with character, press back/forward on previous character roll.